### PR TITLE
Fix task: Add packagecloud apt key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,9 @@
 # Install dokku
 - name: "Add packagecloud apt key"
   apt_key:
-    url: "https://packagecloud.io/gpg.key"
-    id: "C2E73424D59097AB"
+    url: "https://packagecloud.io/dokku/dokku/gpgkey"
+    id: "FB2B6AA421CD193F"
+
 - name: "Add apt repository of dokku"
   apt_repository:
     repo: "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main"
@@ -51,6 +52,7 @@
   apt:
     name: dokku
     install_recommends: yes
+    update_cache: yes
 
 - name: "Install plugin"
   command: >-


### PR DESCRIPTION
This task was using an outdated method for getting the repository sign for installing dokku/dokku according to the [documentation](https://packagecloud.io/docs#gpg_migration) :

> Legacy GPG keys
> In the early days of packagecloud, the service used a global GPG key to sign the repository metadata generated for all APT and YUM repositories created.

Now basing on this [page](https://packagecloud.io/app/dokku/dokku/gpg#gpg-apt) i updated the url and id of the task apt.
Finnaly I set the update cache to yes in task(install dokku), just to be sure the repository sources list is up to date.

[Ansible Documentation Apt](https://docs.ansible.com/ansible/latest/modules/apt_module.html)
> Run the equivalent of apt-get update before the operation. Can be run as part of the package installation or as a separate step.